### PR TITLE
feat: add error messages

### DIFF
--- a/lib/passport-oauth2-public-client/strategy.js
+++ b/lib/passport-oauth2-public-client/strategy.js
@@ -36,7 +36,7 @@ util.inherits(Strategy, passport.Strategy);
  */
 Strategy.prototype.authenticate = function(req) {
   if (!req.body || !req.body['client_id']) {
-    return this.fail();
+    return this.fail('Missing client_id');
   }
 
   var clientId = req.body['client_id'];
@@ -45,7 +45,7 @@ Strategy.prototype.authenticate = function(req) {
 
   function verified(err, client, info) {
     if (err) { return self.error(err); }
-    if (!client) { return self.fail(); }
+    if (!client) { return self.fail('Invalid client_id'); }
     self.success(client, info);
   }
 


### PR DESCRIPTION
when using passport strategy with custom callback, you can pass error description to this callback

```
passport.authenticate('oauth2-public-client', { session: false }, function(req, res, next) {
    return function(err, user, info, status) {
      console.log(err, user, info, status);
      // info = 'Missing client_id | Invalid client_id'
      if (err) {
        return next(err);
      }

      if (!user) {
        return next(new AuthenticationError(info, status));
      }
      req.logIn(user, { session: false });
      return next();
    }
  }))(req, res, next);
```